### PR TITLE
Update accelerometer dependency

### DIFF
--- a/demo-ng/package.json
+++ b/demo-ng/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser-dynamic": "2.0.0",
     "@angular/platform-server": "2.0.0",
     "@angular/router": "3.0.0",
-    "nativescript-accelerometer": "^0.3.2",
+    "nativescript-accelerometer": "^1.0.0",
     "nativescript-angular": "1.0.0",
     "nativescript-mip-ble": "file:..",
     "reflect-metadata": "^0.1.8",

--- a/demo/package.json
+++ b/demo/package.json
@@ -9,7 +9,7 @@
     }
   },
   "dependencies": {
-    "nativescript-accelerometer": "^0.3.2",
+    "nativescript-accelerometer": "^1.0.0",
     "nativescript-color-picker": "^1.3.1",
     "nativescript-drop-down": "^1.3.3",
     "nativescript-joystick": "^0.4.2",


### PR DESCRIPTION
`nativescript-accelerometer` update - It was occasionally causing runtime errors, because it had a dependency to an old version of `tns-core-modules`